### PR TITLE
Use qld-gov-au/ckanext-s3filestore

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -17,7 +17,7 @@ jobs:
     env:
       IMAGE_NAME: ckan
       DOCKER_BUILDKIT: 1
-      S3_FILESTORE_VERSION: v1.0.0
+      S3_FILESTORE_VERSION: develop
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ RUN pip install --user "git+https://github.com/ckan/ckan.git@ckan-${CKAN_VERSION
 
 
 FROM build-base as s3filestore
-ARG S3_FILESTORE_VERSION=v1.0.0
+ARG S3_FILESTORE_VERSION=develop
 
-RUN pip install --user -r "https://raw.githubusercontent.com/keitaroinc/ckanext-s3filestore/${S3_FILESTORE_VERSION}/requirements.txt"
-RUN pip install --user "git+https://github.com/keitaroinc/ckanext-s3filestore.git@${S3_FILESTORE_VERSION}#egg=ckanext-s3filestore"
+RUN pip install --user -r "https://raw.githubusercontent.com/qld-gov-au/ckanext-s3filestore/${S3_FILESTORE_VERSION}/requirements.txt"
+RUN pip install --user "git+https://github.com/qld-gov-au/ckanext-s3filestore.git@${S3_FILESTORE_VERSION}#egg=ckanext-s3filestore"
 
 
 FROM python:3.8-slim

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       args:
         - CKAN_VERSION=2.9.4
-        - S3_FILESTORE_VERSION=v1.0.0
+        - S3_FILESTORE_VERSION=develop
     depends_on:
       solr:
         condition: service_started

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -49,7 +49,6 @@ update_config () {
   fi
   if [ ! -z ${MINIO_PATH} ]; then
     ckan config-tool ${CONFIG} ckanext.s3filestore.host_name=${MINIO_PATH}
-    ckan config-tool ${CONFIG} ckanext.s3filestore.download_proxy=${MINIO_PATH}
   fi
   if [ ! -z ${CKANEXT_S3FILESTORE_ACL} ]; then
     ckan config-tool ${CONFIG} ckanext.s3filestore.acl=${CKANEXT_S3FILESTORE_ACL}


### PR DESCRIPTION
Use [qld-gov-au/ckanext-s3filestore](https://github.com/qld-gov-au/ckanext-s3filestore) because of compatibility for CKAN 2.9.
